### PR TITLE
is there any specific reason for :method => 'post'?

### DIFF
--- a/lib/devise_openid_authenticatable/strategy.rb
+++ b/lib/devise_openid_authenticatable/strategy.rb
@@ -12,7 +12,7 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
     if provider_response
       handle_response!
     else # Delegate authentication to Rack::OpenID by throwing a 401
-      opts = { :identifier => params[scope]["identity_url"], :return_to => return_url, :trust_root => trust_root, :method => 'post' }
+      opts = { :identifier => params[scope]["identity_url"], :return_to => return_url, :trust_root => trust_root }
       opts[:immediate] = true if params[scope]["immediate"]
       opts[:optional] = mapping.to.openid_optional_fields if mapping.to.respond_to?(:openid_optional_fields)
       opts[:required] = mapping.to.openid_required_fields if mapping.to.respond_to?(:openid_required_fields)


### PR DESCRIPTION
Is there any specific reason for :method => 'post' while handling response with Rack::OpenID.build_header() ?

I'm using just this w/o devise database_authenticatable. After successful auth I'd like the user to be redirected right where they came from and Rails obviously complaining about "no such action X with method POST" after a (successful) redirect but with this additional param _method=post.

It's not really a pull request. I'm assuming this is just to get back to the correct sessions#create action at the end of successful auth. Just asking whether there's something more to it, like some openid 2.0 requirements or whatever. 

thanks.
