### PR TITLE
Add authenticity token to return parameters

### DIFF
--- a/lib/devise_openid_authenticatable/strategy.rb
+++ b/lib/devise_openid_authenticatable/strategy.rb
@@ -115,12 +115,15 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
     
     def return_url
       return_to = URI.parse(request.url)
-      scope_params = params[scope].inject({}) do |return_params, pair|
+      return_params = params[scope].inject({}) do |request_params, pair|
         param, value = pair
-        return_params["#{scope}[#{param}]"] = value
-        return_params
+        request_params["#{scope}[#{param}]"] = value
+        request_params
       end
-      return_to.query = Rack::Utils.build_query(scope_params)
+      if params[:authenticity_token]
+        return_params['authenticity_token'] = params[:authenticity_token]
+      end
+      return_to.query = Rack::Utils.build_query(return_params)
       return_to.to_s
     end
 


### PR DESCRIPTION
Devise is not storing the authenticated user in the session anymore if CSRF token validation fails.
https://github.com/plataformatec/devise/blob/master/lib/devise/strategies/base.rb#L5

I had to face this issue after recognizing, that (even after a successful authentication through the OpenID provider) the user was not kept logged in. I fixed the problem by sending the authenticity token with the return parameters.

CSRF token validation is turned off in tests. It would be an option to turn it on. But this would break two other tests.
