### PR TITLE
Made identity_url globally configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Installation
 Add the following to your project's Gemfile:
 
     gem "devise_openid_authenticatable"
-    
+
 Then run `bundle install`.
-    
+
 Setup
 -----
 
 Once devise\_openid\_authenticatable is installed, add the following to your user model:
 
     devise :openid_authenticatable
-    
+
 You can also add other modules such as token_authenticatable, trackable, etc.  Database_authenticatable
 should work fine alongside openid_authenticatable.
 
@@ -41,7 +41,21 @@ You'll also need to set up the database schema for this:
 and, optionally, indexes:
 
     add_index :users, :identity_url, :unique => true
-    
+
+## Option 1: Configure a global identity_url
+If the identity URL does not vary per user and you do not want to bother users with that you can configure a static identity URL through Devise.
+
+In `config/initializers/devise.rb`, add:
+
+```
+Devise.setup do |config|
+  config.openid_authenticatable do |openid|
+    openid.identity_url = 'http://foobar.com'
+  end
+end
+```
+
+## Option 2: Pass the identity_url along via the login form
 In addition, you'll need to modify sessions/new.html.erb (or the appropriate scoped view if you're
 using those).  You need to add a field for identity_url, and remove username and password if you
 aren't using database_authenticatable:
@@ -57,6 +71,7 @@ aren't using database_authenticatable:
       <p><%= f.submit "Sign in" %></p>
     <% end -%>
 
+## Rails 2
 Finally, *Rails 2* users, you'll need to wire up Rack::OpenID in your Rails configuration:
 
     config.middleware.insert_before(Warden::Manager, Rack::OpenID)
@@ -74,12 +89,12 @@ to your user model class:
 
     class User < ActiveRecord::Base
       devise :openid_authenticatable
-      
+
       def self.build_from_identity_url(identity_url)
         User.new(:identity_url => identity_url)
       end
     end
-    
+
 SReg and AX Extensions
 ----------------------
 
@@ -91,25 +106,25 @@ To add SReg and AX support to your User model, you'll need to do two things: fir
 fields you'd like to request from OpenID providers.  Second, you need to provide a method for processing
 these fields during authentication.
 
-To specify which fields to request, you can implement one (or both) of two class methods: 
+To specify which fields to request, you can implement one (or both) of two class methods:
 openid_required_fields and openid_optional_fields.  For example:
 
     def self.openid_required_fields
       ["fullname", "email", "http://axschema.org/namePerson", "http://axschema.org/contact/email"]
     end
-    
+
     def self.openid_optional_fields
       ["gender", "http://axschema.org/person/gender"]
     end
 
 Required fields should be used for fields without which your app can't operate properly.  Optional fields
 should be used for fields which are nice to have, but not necessary for your app.  Note that just because you
-specify a field as "required" doesn't necessarily mean that the OpenID provider has to give it to you (for 
+specify a field as "required" doesn't necessarily mean that the OpenID provider has to give it to you (for
 example, a provider might not have that field for its users).
 
 In the above example, we're specifying both SReg fields (fullname, email, and gender) and the equivalent
 AX fields (the ones that look like URLs).  A list of defined AX fields and their equivalent SReg fields can
-be found at [http://www.axschema.org/types](http://www.axschema.org/types).  It is highly recommended to 
+be found at [http://www.axschema.org/types](http://www.axschema.org/types).  It is highly recommended to
 specify both AX and SReg fields, as both are implemented by different common OpenID providers.
 
 Once a successful OpenID response comes back, you still need to process the fields that the provider returned
@@ -122,7 +137,7 @@ maps each returned field to a string value.  For example:
         if value.is_a? Array
           value = value.first
         end
-      
+
         case key.to_s
         when "fullname", "http://axschema.org/namePerson"
           self.name = value

--- a/lib/devise_openid_authenticatable.rb
+++ b/lib/devise_openid_authenticatable.rb
@@ -1,5 +1,6 @@
 require 'devise'
 
+require 'devise_openid_authenticatable/config'
 require 'devise_openid_authenticatable/railtie'
 require 'devise_openid_authenticatable/schema'
 require 'devise_openid_authenticatable/strategy'

--- a/lib/devise_openid_authenticatable/config.rb
+++ b/lib/devise_openid_authenticatable/config.rb
@@ -1,0 +1,27 @@
+module DeviseOpenidAuthenticatable
+  module Config
+
+    mattr_accessor :identity_url
+
+  end
+end
+
+module DeviseOpenidAuthenticatable
+  module Configurable
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+
+      def openid_authenticatable
+        yield DeviseOpenidAuthenticatable::Config
+      end
+
+    end
+
+  end
+end
+
+Devise.send(:include, DeviseOpenidAuthenticatable::Configurable)

--- a/lib/devise_openid_authenticatable/strategy.rb
+++ b/lib/devise_openid_authenticatable/strategy.rb
@@ -2,6 +2,7 @@ require 'devise/strategies/base'
 require 'rack/openid'
 
 class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authenticatable
+
   def valid?
     valid_mapping? && ( provider_response? || identity_param? )
   end
@@ -12,14 +13,15 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
     if provider_response
       handle_response!
     else # Delegate authentication to Rack::OpenID by throwing a 401
-      opts = { :identifier => params[scope]["identity_url"], :return_to => return_url, :trust_root => trust_root, :method => 'post' }
-      opts[:immediate] = true if params[scope]["immediate"]
+      opts = { :identifier => identity_url, :return_to => return_url, :trust_root => trust_root, :method => 'post' }
+
+      opts[:immediate] = true if scoped_params["immediate"]
       opts[:optional] = mapping.to.openid_optional_fields if mapping.to.respond_to?(:openid_optional_fields)
       opts[:required] = mapping.to.openid_required_fields if mapping.to.respond_to?(:openid_required_fields)
       custom! [401, { Rack::OpenID::AUTHENTICATE_HEADER => Rack::OpenID.build_header(opts) }, "Sign in with OpenID"]
     end
   end
-  
+
   # CSRF won't be able to be verified on returning from the OpenID server, so we will bypass that check for this strategy
   def store?
     true
@@ -30,11 +32,10 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
     # Handles incoming provider response
     def handle_response!
       logger.debug "Attempting OpenID auth: #{provider_response.inspect}"
-      
+
       case provider_response.status
       when :success
         resource = find_resource || build_resource || create_resource
-        
         if resource && validate(resource)
           begin
             update_resource!(resource)
@@ -69,19 +70,19 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
     end
 
     def identity_param?
-      params[scope].try(:[], 'identity_url').present?
+      identity_url.present?
     end
-    
+
     def find_resource
       mapping.to.find_by_identity_url(provider_response.identity_url)
     end
-    
+
     def build_resource
       if mapping.to.respond_to?(:build_from_identity_url)
         mapping.to.build_from_identity_url(provider_response.identity_url)
       end
     end
-    
+
     def create_resource
       if mapping.to.respond_to?(:create_from_identity_url)
         logger.warn "DEPRECATION WARNING: create_from_identity_url is deprecated.  Please implement build_from_identity_url instead.  For more information, please see the devise_openid_authenticatable CHANGELOG for version 1.0.0.beta1."
@@ -93,13 +94,13 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
       if fields && resource.respond_to?(:openid_fields=)
         resource.openid_fields = fields
       end
-      
+
       resource.save!
     end
-    
+
     def fields
       return @fields unless @fields.nil?
-      
+
       if axr = OpenID::AX::FetchResponse.from_success_response(provider_response)
         @fields = axr.data
       else
@@ -110,17 +111,17 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
           end
         end
       end
-      
+
       return @fields
     end
 
     def logger
       @logger ||= ((Rails && Rails.logger) || RAILS_DEFAULT_LOGGER)
     end
-    
+
     def return_url
       return_to = URI.parse(request.url)
-      return_params = params[scope].inject({}) do |request_params, pair|
+      return_params = (scoped_params).inject({}) do |request_params, pair|
         param, value = pair
         request_params["#{scope}[#{param}]"] = value
         request_params
@@ -135,6 +136,15 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
       trust_root.query = nil
       trust_root.to_s
     end
+
+    def scoped_params
+      params[scope] || {}
+    end
+
+    def identity_url
+      params[scope].try(:[], 'identity_url') || DeviseOpenidAuthenticatable::Config.identity_url
+    end
+
 end
 
 Warden::Strategies.add :openid_authenticatable, Devise::Strategies::OpenidAuthenticatable


### PR DESCRIPTION
I needed the `identity_url`to be static over all users, and thus to be configurable.