### PR TITLE
Discuss: Why not add fields as param to build_from_identity_url

### DIFF
--- a/lib/devise_openid_authenticatable/strategy.rb
+++ b/lib/devise_openid_authenticatable/strategy.rb
@@ -79,7 +79,7 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
 
     def build_resource
       if mapping.to.respond_to?(:build_from_identity_url)
-        mapping.to.build_from_identity_url(provider_response.identity_url)
+        mapping.to.build_from_identity_url(provider_response.identity_url,fields)
       end
     end
 


### PR DESCRIPTION
> For discussion not approval/merge.  Please share your thoughts

I've started using this openid module in conjunction with existing database_authenticatable users in my app.  I looked at the wiki doc on strategy

> https://github.com/nbudin/devise_openid_authenticatable/wiki/Using-database_authenticatable-and-openid_authenticatable-together

But this seems unnecessarily complex when dealing with the cases

* Matching an openid identity to an existing user (via email)
* creating a new user from an openid identity

Because the gem's workflow first creates a new user (when no identity url matches) but does not pass along the fields.  

My patch includes the fields into the build class method on the resource (User).  This allows one to handle these cases IMHO more simply with a method like:

````
def self.build_from_identity_url(identity_url,fields=nil)


    email = fields['http://openid.net/schema/contact/internet/email'].try(:[],0)
    name = fields['http://axschema.org/namePerson'].try(:[],0)
    first=fields['http://axschema.org/namePerson/first'].try(:[],0)
    last=fields['http://axschema.org/namePerson/last'].try(:[],0)

    mobile = fields['http://openid.net/schema/contact/phone/business'].try(:[],0)

    if user=User.find_by_email(email)
      user.identity_url=identity_url
    else
      user=User.new(:identity_url => identity_url)
      user.email=email
      user.name= name
      user.given_name=first
      user.family_name=last
      user.mobile=mobile
      user.password=SecureRandom.hex(10)
    end

    user

  end
````