### PR TITLE
use ENV instead of env

### DIFF
--- a/lib/devise_openid_authenticatable/controller.rb
+++ b/lib/devise_openid_authenticatable/controller.rb
@@ -1,18 +1,18 @@
 module DeviseOpenidAuthenticatable
   module Controller
     extend ActiveSupport::Concern
-    
+
     included do
       alias_method_chain :verify_authenticity_token, :openid_response_check
     end
-        
+
     protected
     def verify_authenticity_token_with_openid_response_check
       verify_authenticity_token_without_openid_response_check unless openid_provider_response?
     end
-    
+
     def openid_provider_response?
-      !!env[Rack::OpenID::RESPONSE]
+      !!ENV[Rack::OpenID::RESPONSE]
     end
   end
 end

--- a/lib/devise_openid_authenticatable/strategy.rb
+++ b/lib/devise_openid_authenticatable/strategy.rb
@@ -67,7 +67,7 @@ class Devise::Strategies::OpenidAuthenticatable < Devise::Strategies::Authentica
     end
 
     def provider_response
-      env[Rack::OpenID::RESPONSE]
+      ENV[Rack::OpenID::RESPONSE]
     end
 
     def valid_mapping?


### PR DESCRIPTION
solves deprecation:
DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1 (called from openid_provider_response? at /Users/netengine100/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/devise_openid_authenticatable-1.2.1/lib/devise_openid_authenticatable/controller.rb:15)