### PR TITLE
cleanup deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
 source 'https://rubygems.org'
 
+ruby '2.3.1'
+
 # Specify your gem's dependencies in devise_openid_authenticatable.gemspec
 gemspec
 
+gem 'rails', '~> 4.0.0'
+gem 'devise', '~> 3.0.0'
+
 group :test do
-  gem "rots", :git => "http://github.com/roman/rots.git"
+  gem "rots", github: "roman/rots"
+  gem "test-unit" # Needed for github rspec/rspec-rails/issues/1273
 end

--- a/lib/devise_openid_authenticatable/controller.rb
+++ b/lib/devise_openid_authenticatable/controller.rb
@@ -1,16 +1,16 @@
 module DeviseOpenidAuthenticatable
   module Controller
     extend ActiveSupport::Concern
-    
+
     included do
       alias_method_chain :verify_authenticity_token, :openid_response_check
     end
-        
+
     protected
     def verify_authenticity_token_with_openid_response_check
       verify_authenticity_token_without_openid_response_check unless openid_provider_response?
     end
-    
+
     def openid_provider_response?
       !!env[Rack::OpenID::RESPONSE]
     end

--- a/spec/scenario/config/environments/test.rb
+++ b/spec/scenario/config/environments/test.rb
@@ -8,7 +8,8 @@ Scenario::Application.configure do
   config.cache_classes = true
 
   # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
+  # DEPRECATION WARNING: config.whiny_nils option is deprecated and no longer works.
+  # config.whiny_nils = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
@@ -30,6 +31,6 @@ Scenario::Application.configure do
   config.action_dispatch.show_exceptions = false
 
   config.active_support.deprecation = :stderr
-  
+
   config.eager_load = false
 end

--- a/spec/scenario/config/initializers/secret_token.rb
+++ b/spec/scenario/config/initializers/secret_token.rb
@@ -1,2 +1,3 @@
 Rails.application.config.secret_token = 'ea942c41850d502f2c8283e26bdc57829f471bb18224ddff0a192c4f32cdf6cb5aa0d82b3a7a7adbeb640c4b06f3aa1cd5f098162d8240f669b39d6b49680571'
-Rails.application.config.session_store :cookie_store, :key => "_my_scenario"
+Rails.application.config.session_store :cookie_store, key: "_my_scenario"
+Scenario::Application.config.secret_key_base = 'ea942c41850d502f3c8283e26bdc57829f471bb18224ddff0a192c4f32cdf6cb5aa0d82b3a7a7adbeb640c4b06f3aa1cd5f098162d8240f669b39d6b49680574'


### PR DESCRIPTION
I had some problems running the tests, which I solved looking at the other Gemfiles and adding the missing dependencies.

I'm not sure how I was supposed to use the Gemfile the way it was because Rails was not defined as a dependency anywhere.

Happy to change it if I get to grasp it.

At least I can run the specs now (:
